### PR TITLE
Fix error where an identified barcode contained only -

### DIFF
--- a/bin/extract_barcode.py
+++ b/bin/extract_barcode.py
@@ -459,6 +459,9 @@ def align_adapter(tup):
 
         # Require minimum read1 edit distance
         if adapter1_ed <= args.max_adapter1_ed:
+            # Require informative characters in identified barcode
+            if barcode.__eq__("-" * args.barcode_length):
+                continue
             qscores, min_qv = find_feature_qscores(
                 barcode, p_alignment, prefix_seq, prefix_qv)
 


### PR DESCRIPTION
Small bug fix to avoid pipeline crashing during the extract_barcodes step when a parasail alignment yields a barcode consisting only of "-".

The issue occurs for instance with the following read from a 5prime 10X Gene Expression library sequenced with SQK-LSK114 and re-basecalled with a 260bp sup model :

```
4d50c276-10fc-40db-ac34-fa748983b5d7_0	16	chr14	68874297	60	73S171M2D17M1D13M1I131M5D30M1D254M2I96M2064N159M1748N51M12D2M2D14M892N11M2D134M701N2M5D108M33S	*	0	0	ACTCGTTCAGTTACGTATTGCTATAAACACAAGGCACTCTCTCTCTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTCTCTTCCTTAAAAAACAGCCATTTCAAAAGATTTTCTTTAATATCATAAAATATTTTCATGGACAAGTGAGCTAGCAAACACACATGCACCAATGTGCCTTTTGACAAGAGTACCCCCTACCCCGACTCCCACACCAAAATGGACATGAGATTGGAGAAATGAATACAGGATGGAACAGATAGAAGAAAAAAAATCGGTGAAAAAGGATGGAATATAACTTTGTGCTTGGTTATTTTCCTATGTCGCAACAAAACAAGACATTTCGGTGCAAATAGTTAATCTTTCCTCTTTTTTTCCATTTGTCTGGTGGAGAAAAAATACTTTTTCTATAATATGTAGTTTTTTGGTTTTTAACGTAACTTTTTTTCTTTTTTGCAGAAAATAATTTTGTAAACTGTCACTTCGCGGGCAGGGAGGATCGATGCCACGTGGGCCCCAGCTCACCCGGGTGGAGGCTGGGAGCTGAAACCGAACCCAGGCAGGAGATGGGCGACGGCGGAGGTGCAAGGCAGGGCACGGCGCACAAGACGAGGGCGGCCGGGCGGGGTGGATTAGAGGTCACTCTCGCCGTACAGCGCCGTGGAGAAGGACATGTAGTCCAGAGCACCTGGCACCACGAGTCGGGGCCGGAGTAGGGGGCCATCCGCGCGATGCAGTACTCAGCCTGGTCGGGTGGCAGCTCGCGGCGCAGCTCGTCCATGGTAATGTAGTTCTTGTCCCCAGCCAGGATCTTGAAGGAAGCCATGACTTGGTCTGCTGTATCTGTGTCGGCTGTCTCGCGGGACATGAAGTCAATGAAGGCCTGGAATGTCACTACCCCCAGGCGGTTGGGGTCCACAATGCTCATGATGCGGGCAAATTCTGCTTCTCCCTGGGGGTCGTTGCCAATATCATAACCCAAGCTGATGAGGCAGGCTTTGAACAGTGCCGGAGTGATCCCGGTCAAAGTTTGAAGGAGGCCCGGAACTCATTCATCTGCTCCTGGCTGATGCCCTTGGCATCCCGGGTCAGGATCTGGTTCTCTACCTCATTGATGGTCCTGGCGATGGTGGTGAGCAGCTGCTCCCAGCCCACACGGATGTGCTGTGTAGTTGGTGTGCTTGTTGTCGAAGATGAGCGCCTCCTGGATGAGCTGGTGGTCGCCCTCCAGCTGATCAATCTTTGGCTTGTAGTTGACGATGCTCTTCTCATACCCCATATAAGAAAATATAGTGCAGATCGGAAGG	"#%&''004333..---22322###$%$$&((&$#""####'()))('**+.2478:<=>?@@@@>951.:?BEED;988;9;;;;ACGGBAA@>?@@CECCCCIEFEGNLDCDENJJJGEFFIMOLKHFGFFAAAA@?@ACEFECA@@@CDEFGHGGEGDAAA@ABCCDFFDA@?DE9998;;:;::<=?ADC???>;999:?C>442..;<=CGHCDCCCCC@@ABACCBDFFGFDECAAA5DBBB???@@?><554ECDECHKLMLP>+()''()5=F:999=>>@@GEDAAAB@BA<<=><@@@@HIGJ==<<<@A===>@DNRNH)(((*;;>>>9988:BBCJLGFCFDH?9999<:997-));??C@@AFDCA??@AB31-++.4:>??;9:8;>=989-DDFR@??A:52BIHA?>??CLPK>;;;<?CB;J>KKK;63;:=<>?ABDGLMLHBABCBJLIJHHGGFHGE;4337221/-)*++...0////8A@?>@@>>??>DDEE>///?@@AA@BDEDEFHGDBBAACEEJEAA??>?BC99955=?CEEECCCB>?>>HHHGJJIIKQHGJIKDHGGFGFGFHEEDCBBBBAA@CBFGIJNIHIIHFJIHJHF<771...034FFHHHHHHHIEDEEEHGHHGGGGFFHIIIKKIGHD@@@@CFGKLJGEDDEGFB?.*)(%$$&*.878820-+*+3437?FEGFGHHJLGFEDCCBA@@?@@BBEEEEEFFGAAABDEEIHF<778@>?>?>BEECCC@A@ADFBBCCDFEEFECCCC611;2?AB@@AAACCDEEGFDEEDCDCA@@@@BBCBBAAABC@@A@@BBBFC@@@AEDBA?<<<<A@EEEEFGGFHGILGDCCAA@====@BCPIDDBA><887526..699;C@@;DDDCDFFFFECDDEICA=>>>>AE>;<5*(%%%&&&/5.7?>@C@@@@ACDDDDDEGECDDFFEC:::::B@ABBBAA?@ABCGC:3/&##$%(.38:@@@ACBAB9DDEBB@9.+/99DCFGFEED?>===@BAAA@BBA@CCAAA??BCFFEDDEDDCAC?>AB@@>:+),(9<?AECABAADD@?74)))9;<>FHEDDCBAA@AB?<<<<?BBABCDCBBBAA:55B7;(?ABA@?:98<<<>FEC4EGGHFHGGGFEGECCCCFGJHF2211.10++,,16681112ABKKPPLJG?>>>>CDCCCBCBCDDHGHJC7145:83-.;:<<>ABBCCFFFEFEC@@@@BDDDABA>>@@AJNFB;4+).--*#$'(('('''((1.,$	NM:i:36	ms:i:1146	AS:i:1075	nn:i:0	ts:A:+	tp:A:P	cm:i:334	s1:i:1086	s2:i:79	de:f:0.0108	MD:Z:171^CA17^A10A133^AATAA30^T254G13T291^CTCCTCGGGACC2^GT25^GG136^CCATG108	rl:i:58
```

which gives the following error when the latest prerelease version of the pipeline is run using nextflow+singularity:
```
  Loading barcodes in 737K-august-2016.txt.gz: 0 barcodes [00:00, ? barcodes/s]
  Loading barcodes in 737K-august-2016.txt.gz: 199663 barcodes [00:00, 1996531.94 barcodes/s]
  Loading barcodes in 737K-august-2016.txt.gz: 427572 barcodes [00:00, 2162710.09 barcodes/s]
  Loading barcodes in 737K-august-2016.txt.gz: 654833 barcodes [00:00, 2212859.01 barcodes/s]
  Loading barcodes in 737K-august-2016.txt.gz: 737280 barcodes [00:00, 2192953.94 barcodes/s]
  2022-09-24 17:49:01 -- Extracting uncorrected barcodes from OCI-AML-3_sorted.bam

    0%|          | 0/72 [00:00<?, ?it/s]
    1%|▏         | 1/72 [07:02<8:19:29, 422.10s/it]
    7%|▋         | 5/72 [07:02<1:34:16, 84.42s/it]
  multiprocessing.pool.RemoteTraceback:
  """
  Traceback (most recent call last):
    File "/home/epi2melabs/conda/lib/python3.8/multiprocessing/pool.py", line 125, in worker
      result = (True, func(*args, **kwds))
    File "/user/xxx/.nextflow/assets/epi2me-labs/wf-single-cell/bin/extract_barcode.py", line 462, in align_adapter
      qscores, min_qv = find_feature_qscores(
    File "/user/xxx/.nextflow/assets/epi2me-labs/wf-single-cell/bin/extract_barcode.py", line 386, in find_feature_qscores
      return feature_qv_ascii, min(feature_qv)
  ValueError: min() arg is an empty sequence
  """

  The above exception was the direct cause of the following exception:

  Traceback (most recent call last):
    File "/user/xxx/.nextflow/assets/epi2me-labs/wf-single-cell/bin/extract_barcode.py", line 598, in <module>
      main(args)
    File "/user/xxx/.nextflow/assets/epi2me-labs/wf-single-cell/bin/extract_barcode.py", line 563, in main
      results = launch_pool(align_adapter, func_args, args.threads)
    File "/user/xxx/.nextflow/assets/epi2me-labs/wf-single-cell/bin/extract_barcode.py", line 289, in launch_pool
      results = list(tqdm(p.imap(func, func_args), total=len(func_args)))
    File "/home/epi2melabs/conda/lib/python3.8/site-packages/tqdm/std.py", line 1195, in __iter__
      for obj in iterable:
    File "/home/epi2melabs/conda/lib/python3.8/multiprocessing/pool.py", line 868, in next
      raise value
  ValueError: min() arg is an empty sequence`
```