### PR TITLE
Time directives for all processes

### DIFF
--- a/lib/ingress.nf
+++ b/lib/ingress.nf
@@ -504,7 +504,7 @@ process fastcat {
     label "wf_common"
     cpus 4
     memory "2 GB"
-    time "01:00:00"
+    time "04:00:00"
     input:
         tuple val(meta), path(input_src, stageAs: "input_src")
         val fcargs

--- a/lib/ingress.nf
+++ b/lib/ingress.nf
@@ -504,6 +504,7 @@ process fastcat {
     label "wf_common"
     cpus 4
     memory "2 GB"
+    time "01:00:00"
     input:
         tuple val(meta), path(input_src, stageAs: "input_src")
         val fcargs
@@ -556,6 +557,7 @@ process checkBamHeaders {
     label "wf_common"
     cpus 1
     memory "2 GB"
+    time "01:00:00"
     input: tuple val(meta), path("input_dir/reads*.bam")
     output:
         tuple(
@@ -582,6 +584,7 @@ process validateIndex {
     label "wf_common"
     cpus 1
     memory "2 GB"
+    time "01:00:00"
     input: tuple val(meta), path("reads.bam"), path("reads.bam.bai")
     output:
         // set the two env variables by `eval`-ing the output of the python script
@@ -605,6 +608,7 @@ process mergeBams {
     label "wf_common"
     cpus 3
     memory "4 GB"
+    time "01:00:00"
     input: tuple val(meta), path("input_bams/reads*.bam"), path("input_bams/reads*.bam.bai")
     output: tuple val(meta), path("reads.bam"), path("reads.bam.bai")
     script:
@@ -621,6 +625,7 @@ process catSortBams {
     label "wf_common"
     cpus 4
     memory "4 GB"
+    time "01:00:00"
     input: tuple val(meta), path("input_bams/reads*.bam")
     output: tuple val(meta), path("reads.bam"), path("reads.bam.bai")
     script:
@@ -637,6 +642,7 @@ process sortBam {
     label "wf_common"
     cpus 3
     memory "4 GB"
+    time "08:00:00"
     input: tuple val(meta), path("reads.bam")
     output: tuple val(meta), path("reads.sorted.bam"), path("reads.sorted.bam.bai")
     script:
@@ -652,6 +658,7 @@ process bamstats {
     label "wf_common"
     cpus 3
     memory "4 GB"
+    time "01:00:00"
     input:
         tuple val(meta), path("reads.bam"), path("reads.bam.bai")
         val bsargs
@@ -778,6 +785,7 @@ process move_or_compress_fq_file {
     label "wf_common"
     cpus 1
     memory "2 GB"
+    time "01:00:00"
     input:
         // don't stage `input` with a literal because we check the file extension
         tuple val(meta), path(input)
@@ -804,6 +812,7 @@ process split_fq_file {
     label "wf_common"
     cpus 1
     memory "2 GB"
+    time "01:00:00"
     input:
         // don't stage `input` with a literal because we check the file extension
         tuple val(meta), path(input)
@@ -1098,6 +1107,7 @@ process validate_sample_sheet {
     label "ingress"
     label "wf_common"
     memory "2 GB"
+    time "01:00:00"
     input:
         path "sample_sheet.csv"
         val required_sample_types
@@ -1115,6 +1125,7 @@ process samtools_index {
     cpus 4
     label "ingress"
     label "wf_common"
+    time "01:00:00"
     memory 4.GB
     input:
         tuple val(meta), path("reads.bam")

--- a/main.nf
+++ b/main.nf
@@ -14,6 +14,7 @@ process getVersions {
     label "singlecell"
     cpus 1
     memory "1 GB"
+    time "01:00:00"
     output:
         path "versions.txt"
     script:

--- a/main.nf
+++ b/main.nf
@@ -39,6 +39,7 @@ process getParams {
     label "singlecell"
     cpus 1
     memory "1 GB"
+    time "01:00:00"
     output:
         path "params.json"
     script:
@@ -54,6 +55,7 @@ process makeReport {
     label "wf_common"
     cpus 1
     memory "32 GB"
+    time "01:00:00"
     publishDir "${params.out_dir}", mode: 'copy', pattern: "wf-single-cell-report.html"
     input:
         val metadata
@@ -93,6 +95,7 @@ process parse_kit_metadata {
     label "singlecell"
     cpus 1
     memory "1 GB"
+    time "01:00:00"
     input:
         path 'sample_ids'
         path sc_sample_sheet
@@ -125,6 +128,7 @@ process prepare_report_data {
     label "singlecell"
     cpus 1
     memory "1 GB"
+    time "01:00:00"
     input:
         tuple val(meta),
               path('adapter_stats/stats*.json'),

--- a/subworkflows/preprocess.nf
+++ b/subworkflows/preprocess.nf
@@ -1,6 +1,7 @@
 process call_paftools {
     label "singlecell"
     memory "2 GB"
+    time "08:00:00"
     cpus 1
     input:
         path "ref_genes.gtf"
@@ -15,6 +16,7 @@ process call_paftools {
 process get_chrom_sizes {
     label "singlecell"
     memory "1 GB"
+    time "08:00:00"
     cpus 1
     input:
         path "ref_genome.fai"
@@ -33,6 +35,7 @@ process build_minimap_index {
     label "singlecell"
     cpus params.threads
     memory '16 GB'
+    time "08:00:00"
     input:
         path "reference.fa"
     output:
@@ -57,6 +60,7 @@ process call_adapter_scan {
     // peak RSS for aligning this data is robustly <12.4 GB with human reference. Set
     // a little more and do a retry
     memory {15.GB * task.attempt}
+    time "08:00:00"
     maxRetries 1
     errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
     input:
@@ -126,6 +130,7 @@ process summarize_adapter_table {
     publishDir "${params.out_dir}/${meta.alias}", mode: 'copy'
     cpus 1
     memory "1 GB"
+    time "08:00:00"
     input:
         tuple val(meta), path("inputs/summary*.json")
     output:

--- a/subworkflows/process_bams.nf
+++ b/subworkflows/process_bams.nf
@@ -209,7 +209,7 @@ process assign_features {
     // This step is performed per-chromosome. The tags file per chrom can vary
     // quite widely in size. We don't have a fixed memory size here in order
     // to get better parallelism on single-host setups.
-    memory { 1.0.GB.toBytes() + (tags.size() * 2 ) }
+    memory { 2.0.GB.toBytes() + (tags.size() * 2 ) }
     time "08:00:00"
     input:
         tuple val(meta),
@@ -247,8 +247,8 @@ process create_matrix {
     label "singlecell"
     cpus 1
     // Benchmarking showed that memory usage was ~ 15x the size of read_tags input.
-    // Set a minimum memory requirement of 1.0GB to allow for overhead.
-    memory {1.0.GB.toBytes()  + (read_tags.size() * 20) }
+    // Set a minimum memory requirement of 2.0GB to allow for overhead.
+    memory {2.0.GB.toBytes()  + (read_tags.size() * 20) }
     time "08:00:00"
     input:
         tuple val(meta), val(chr), path("features.tsv"), path(read_tags, stageAs: "barcodes.tsv")

--- a/subworkflows/process_bams.nf
+++ b/subworkflows/process_bams.nf
@@ -5,6 +5,7 @@ process split_gtf_by_chroms {
     label "singlecell"
     cpus 1
     memory "1 GB"
+    time "01:00:00"
     input:
         path("ref.gtf")
     output:
@@ -19,6 +20,7 @@ process generate_whitelist{
     label "singlecell"
     cpus 4
     memory "4 GB"
+    time "08:00:00"
     publishDir "${params.out_dir}/${meta.alias}", mode: 'copy'
     input:
         tuple val(meta),
@@ -52,6 +54,7 @@ process assign_barcodes{
     label "singlecell"
     cpus 1
     memory "2 GB"
+    time "08:00:00"
     input:
          tuple val(meta),
                path("whitelist.tsv"),
@@ -79,6 +82,7 @@ process merge_bams {
     label "wf_common"
     cpus params.threads
     memory "8 GB"
+    time "08:00:00"
     input:
         tuple val(meta),
             path('bams/*aln.bam'),
@@ -100,6 +104,7 @@ process cat_tags_by_chrom {
     label "wf_common"
     cpus params.threads
     memory "8 GB"
+    time "08:00:00"
     input:
         tuple val(meta),
               path('tags/*tags.tsv')
@@ -128,6 +133,7 @@ process stringtie {
     cpus params.threads
     // Memory usage for this process is usually less than 3GB, but some cases it may go over this.
     memory = { 3.GB * task.attempt }
+    time "08:00:00"
     maxRetries = 3
     errorStrategy = { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
     input:
@@ -167,6 +173,7 @@ process align_to_transcriptome {
     label "singlecell"
     cpus params.threads
     memory = "32 GB"
+    time "08:00:00"
     input:
         tuple val(meta),
               val(chr),
@@ -203,6 +210,7 @@ process assign_features {
     // quite widely in size. We don't have a fixed memory size here in order
     // to get better parallelism on single-host setups.
     memory { 1.0.GB.toBytes() + (tags.size() * 2 ) }
+    time "08:00:00"
     input:
         tuple val(meta),
               val(chr),
@@ -241,6 +249,7 @@ process create_matrix {
     // Benchmarking showed that memory usage was ~ 15x the size of read_tags input.
     // Set a minimum memory requirement of 1.0GB to allow for overhead.
     memory {1.0.GB.toBytes()  + (read_tags.size() * 20) }
+    time "08:00:00"
     input:
         tuple val(meta), val(chr), path("features.tsv"), path(read_tags, stageAs: "barcodes.tsv")
     output:
@@ -264,6 +273,7 @@ process process_matrix {
     label "singlecell"
     cpus  1
     memory "16 GB"
+    time "08:00:00"
     publishDir "${params.out_dir}/${meta.alias}", mode: 'copy', pattern: "*{mito,umap,raw,processed}*"
     input:
         tuple val(meta), val(feature), path('inputs/matrix*.hdf')
@@ -303,6 +313,7 @@ process merge_transcriptome {
     label "singlecell"
     cpus 2
     memory "2GB"
+    time "08:00:00"
     publishDir "${params.out_dir}/${meta.alias}", mode: 'copy'
     input:
         tuple val(meta),
@@ -330,6 +341,7 @@ process combine_final_tag_files {
     label "singlecell"
     cpus 1
     memory "1 GB"
+    time "08:00:00"
     publishDir "${params.out_dir}/${meta.alias}", mode: 'copy'
     input:
         tuple val(meta),
@@ -347,6 +359,7 @@ process umi_gene_saturation {
     label "singlecell"
     cpus 4
     memory "32 GB"
+    time "08:00:00"
     input:
         tuple val(meta),
               path("read_tags.tsv")
@@ -368,6 +381,7 @@ process pack_images {
     label "singlecell"
     cpus 1
     memory "1 GB"
+    time "08:00:00"
     input:
         tuple val(meta),
               path("images_${meta.alias}/*")
@@ -384,6 +398,7 @@ process tag_bam {
     label "singlecell"
     cpus 4
     memory "16 GB"
+    time "08:00:00"
     publishDir "${params.out_dir}/${meta.alias}", mode: 'copy'
     input:
         tuple val(meta), path('align.bam'), path('align.bam.bai'), path('tags/tag_*.tsv')


### PR DESCRIPTION
Hello,

I'm running wf-single-cell on an HPC system that requires walltime set for submission (via slurm). I could set a general time for all the processes but I think it makes more sense to have process specific walltimes (as overestimation would result in waiting time penalties). This PR sets some ballpark figures for time estimates for all processes. These shouldn't affect 'local' runs, though I haven't got the means to really test this.

Kind regards,

WardDeb